### PR TITLE
fix: exact out amount1 missing negative sign

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 env:
   FOUNDRY_PROFILE: ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,5 @@ jobs:
         run: |
           forge test -vvv
         id: test
+        env:
+          MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 env:

--- a/contracts/Quoter.sol
+++ b/contracts/Quoter.sol
@@ -145,7 +145,7 @@ contract Quoter is IQuoter {
 
         uint256 amountOutCached = 0;
         // if no price limit has been specified, cache the output amount for comparison in the swap callback
-        if (params.sqrtPriceLimitX96 != 0) amountOutCached = params.amount;
+        if (params.sqrtPriceLimitX96 == 0) amountOutCached = params.amount;
 
         QuoterMath.QuoteParams memory quoteParams = QuoterMath.QuoteParams({
             zeroForOne: zeroForOne,
@@ -160,7 +160,7 @@ contract Quoter is IQuoter {
             QuoterMath.quote(pool, -(params.amount.toInt256()), quoteParams);
 
         amountIn = amount0 > 0 ? uint256(amount0) : uint256(amount1);
-        amountReceived = amount0 > 0 ? uint256(-amount1) : uint256(amount0);
+        amountReceived = amount0 > 0 ? uint256(-amount1) : uint256(-amount0);
 
         // did we get the full amount?
         if (amountOutCached != 0) require(amountReceived == amountOutCached);

--- a/test/Quoter.t.sol
+++ b/test/Quoter.t.sol
@@ -15,6 +15,9 @@ contract QuoterTest is Test {
     address usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address eth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
+    address dai = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address wbtc = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+
     function setUp() public {
         mainnetFork = vm.createSelectFork(vm.envString("MAINNET_RPC_URL"));
 
@@ -136,5 +139,32 @@ contract QuoterTest is Test {
 
         assertEq(amountInV2 == amountInV3, true);
         assertEq(sqrtPriceX96AfterV3 == sqrtPriceX96AfterV2, true);
+    }
+
+    function testIlliquidPoolOutputQuoters() public {
+        // 10 wbtc out
+        uint256 amount = 10 * 1e8;
+
+        IQuoterV2.QuoteExactOutputSingleParams memory paramsV2 = IQuoterV2.QuoteExactOutputSingleParams({
+            tokenIn: dai,
+            tokenOut: wbtc,
+            amount: amount,
+            fee: 10000,
+            sqrtPriceLimitX96: 0
+        });
+
+        IQuoter.QuoteExactOutputSingleParams memory paramsV3 = IQuoter.QuoteExactOutputSingleParams({
+            tokenIn: dai,
+            tokenOut: wbtc,
+            amount: amount,
+            fee: 10000,
+            sqrtPriceLimitX96: 0
+        });
+
+        vm.expectRevert();
+        quoterV3.quoteExactOutputSingle(paramsV3);
+
+        vm.expectRevert();
+        quoterV2.quoteExactOutputSingle(paramsV2);
     }
 }


### PR DESCRIPTION
When quoting for exact out against an illiquid pool, we expect the view-only quoter to revert, by hitting https://github.com/Uniswap/view-quoter-v3/blob/064967017bd1a0df11e9d71ff024b29584aafaa5/contracts/Quoter.sol#L166. Right now, because `params.sqrtPriceLimitX96` always equals 0, so `amountOutCached` always equal 0.

The fix is to ensure `amountOutCached` gets used. In additional, when `amount0` is negative, we need to negate it first, before we cast it to `uint256`. This is because EVM uses 2's complement representation for signed integers. For example, if `amount0` is -10001,
 - two's complement binary integer is `1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111101100011101111`. Convert that into `uint256`, it will become 115792089237316195423570985008687907853269984665640564039457584007913129629935 in decimal. 
 - the right fix is to negate `amount0` to 10001, then convert it into `uint256`, so it is still 10001 in decimal, but with 256 bites.

In additional, a new illiquid pool test was written to repro this bug. Also in the workflow config, `workflow_dispatch` means manually run the test. We probably want to run the test per PR as well as per merge.

Also test deployed to mumbai myself with personal test wallet https://mumbai.polygonscan.com/address/0x60e06b92bC94a665036C26feC5FF2A92E2d04c5f#code