### PR TITLE
chore: add polygon into the foundry toml mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,34 @@ The interfaces are the same as the old quoter, but the underlying calls are diff
 This code is unaudited and is a proof of concept.
 
 [Link](https://etherscan.io/address/0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24) to a current deployment at 0x4752ba5DBc23f44D87826276BF6Fd6b1C372aD24 on Mainnet
+
+## Forge CLI
+
+local .env setup:
+
+ ```
+#mainnet
+MAINNET_RPC_URL=<JSON_RPC_PROVIDER>
+MAINNET_ETHERSCAN_API_KEY=<POLYSCAN_API_KEY>
+
+#polygon
+POLYGON_RPC_URL=<JSON_RPC_PROVIDER>
+POLYGON_MUMBAI_RPC_URL=<JSON_RPC_PROVIDER>
+POLYGON_ETHERSCAN_API_KEY=<POLYSCAN_API_KEY>
+
+PRIVATE_KEY=<DEPLOPYER_PK>
+```
+
+forge deploy command:
+```
+forge script  script/Quoter.s.sol:MyScript --chain-id <CHAIN_ID> --rpc-url <NETWORK_ALIAS_IN_FOUNDRYTOML_RPC_ENDPOINTS> \
+ --etherscan-api-key <NETWORK_ALIAS_IN_FOUNDRYTOML_ETHERSCAN> \
+ --broadcast --verify -vvvv
+ ```
+
+For example, deploy to mumbai:
+```
+forge script  script/Quoter.s.sol:MyScript --chain-id 80001 --rpc-url polygon_mumbai \
+ --etherscan-api-key polygon_mumbai \
+ --broadcast --verify -vvvv
+ ```

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,10 @@ libs = ["lib"]
 
 [rpc_endpoints]
 mainnet = "${MAINNET_RPC_URL}"
+polygon = "${POLYGON_RPC_URL}"
+polygon_mumbai = "${POLYGON_MUMBAI_RPC_URL}"
 
 [etherscan]
 mainnet = { key = "${MAINNET_ETHERSCAN_API_KEY}" }
+polygon = { key = "${POLYGON_ETHERSCAN_API_KEY}", chain = 137 }
+polygon_mumbai = { key = "${POLYGON_ETHERSCAN_API_KEY}", chain = 80001 }


### PR DESCRIPTION
It's a good practice to add the networks to foundrytoml mapping we plan to deploy to. Also we are enriching readme with the forge deploy instruction.